### PR TITLE
Adds custom eslintrc and eslint-import rules

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -41,6 +41,7 @@ module.exports = function(
     build: 'react-scripts build',
     test: 'react-scripts test --env=jsdom',
     eject: 'react-scripts eject',
+    lint: 'eslint .',
   };
 
   fs.writeFileSync(
@@ -181,6 +182,9 @@ module.exports = function(
   console.log();
   console.log(chalk.cyan(`  ${displayedCommand} test`));
   console.log('    Starts the test runner.');
+  console.log();
+  console.log(chalk.cyan(`  ${displayedCommand} ${useYarn ? '' : 'run '}lint`));
+  console.log('    Displays lint error.');
   console.log();
   console.log(
     chalk.cyan(`  ${displayedCommand} ${useYarn ? '' : 'run '}eject`)

--- a/packages/react-scripts/template/src/.eslintrc.js
+++ b/packages/react-scripts/template/src/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: ['react-app', 'plugin:import/errors', 'plugin:import/warnings'],
+  settings: {
+    'import/resolver': {
+      node: {
+        paths: ['src'],
+      },
+    },
+  },
+};

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 // In production, we register a service worker to serve assets from local cache.
 
 // This lets the app load faster on subsequent visits in production, and gives

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 // In production, we register a service worker to serve assets from local cache.
 
 // This lets the app load faster on subsequent visits in production, and gives


### PR DESCRIPTION
After `npx create-react-app my-app --scripts-version react-scripts-appier`:
![2018-01-31 2 57 28](https://user-images.githubusercontent.com/108608/35609391-0fa7b02e-0698-11e8-9dd3-1189d4d18815.png)

No lint error for a clean install:
![2018-01-31 3 05 30](https://user-images.githubusercontent.com/108608/35609427-387d2eca-0698-11e8-8a8b-5dc207cdb635.png)


When a typo in import is made:
![2018-01-31 3 01 18](https://user-images.githubusercontent.com/108608/35609400-16199788-0698-11e8-89da-4c23fdaa7aed.png)

