### PR TITLE
Force react-scripts respect user-defined eslint config.

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -147,7 +147,7 @@ module.exports = {
                 extends: [require.resolve('eslint-config-react-app')],
               },
               ignore: false,
-              useEslintrc: false,
+              useEslintrc: true,
               // @remove-on-eject-end
             },
             loader: require.resolve('eslint-loader'),

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -155,7 +155,7 @@ module.exports = {
                 extends: [require.resolve('eslint-config-react-app')],
               },
               ignore: false,
-              useEslintrc: false,
+              useEslintrc: true,
               // @remove-on-eject-end
             },
             loader: require.resolve('eslint-loader'),

--- a/packages/react-scripts/template/.eslintrc.js
+++ b/packages/react-scripts/template/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        paths: ['src'],
+        paths: [`${__dirname}/src`],
       },
     },
   },


### PR DESCRIPTION
For appier forked version, we initially provides eslintrc at create time.
It make no sense the rest of scripts, e.g. eslint, rely on self-defined
eslintrc, but later switch to eslint-config-react-app while using
react-scripts. We should align with eslintrc in anyway to avoid
unexpected lint result between two execution context.t

btw, I've tested this version locally with the instruction from @MrOrz 😄 

Would you help me to review this small patch, and maybe evaluate the impact if any potential risk I didn't think of? Thanks! 
@MrOrz @jihchi 
